### PR TITLE
Adding AWS CFN stack update capability on env prepare

### DIFF
--- a/lib/vm_shepherd/shepherd.rb
+++ b/lib/vm_shepherd/shepherd.rb
@@ -207,13 +207,14 @@ module VmShepherd
       @ami_manager ||=
         VmShepherd::AwsManager.new(
           env_config: {
-                        'stack_name'     => @env_config.dig('stack_name'),
-                        'aws_access_key' => @env_config.dig('aws_access_key'),
-                        'aws_secret_key' => @env_config.dig('aws_secret_key'),
-                        'region'         => @env_config.dig('region'),
-                        'json_file'      => @env_config.dig('json_file'),
-                        'parameters'     => @env_config.dig('parameters'),
-                        'outputs'        => @env_config.dig('outputs'),
+                        'stack_name'        => @env_config.dig('stack_name'),
+                        'aws_access_key'    => @env_config.dig('aws_access_key'),
+                        'aws_secret_key'    => @env_config.dig('aws_secret_key'),
+                        'region'            => @env_config.dig('region'),
+                        'json_file'         => @env_config.dig('json_file'),
+                        'parameters'        => @env_config.dig('parameters'),
+                        'outputs'           => @env_config.dig('outputs'),
+                        'update_existing'  => true == @env_config.dig('update_existing'),
                       }.merge(ami_elb_config),
           logger:     stdout_logger,
         )

--- a/lib/vm_shepherd/version.rb
+++ b/lib/vm_shepherd/version.rb
@@ -1,3 +1,3 @@
 module VmShepherd
-  VERSION = '3.2.1'.freeze
+  VERSION = '3.2.2'.freeze
 end

--- a/spec/vm_shepherd/shepherd_spec.rb
+++ b/spec/vm_shepherd/shepherd_spec.rb
@@ -16,6 +16,7 @@ module VmShepherd
         'aws_secret_key' => 'aws-secret-key',
         'region'         => 'aws-region',
         'json_file'      => 'cloudformation.json',
+        'update_existing' => false,
         'parameters'     => {
           'key_pair_name' => 'key_pair_name'
         },


### PR DESCRIPTION
Adding AWS CFN stack update capability on env prepare - will update a stack if found, and the appropriate flag is set.

Default behaviour is unchanged; no backwards compatibility concerns.

[#128088987]

Signed-off-by: Pierre Delagrave pdelagrave@pivotal.io
